### PR TITLE
Bump add-on for PVR API 3.0.0 (Compatibility mode)

### DIFF
--- a/pvr.njoy/addon.xml.in
+++ b/pvr.njoy/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.njoy"
-  version="1.11.3"
+  version="1.11.4"
   name="Njoy N7 PVR Client"
   provider-name="Team XBMC">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="2.1.0"/>
+    <import addon="xbmc.pvr" version="3.0.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.njoy/changelog.txt
+++ b/pvr.njoy/changelog.txt
@@ -1,3 +1,6 @@
+1.11.4
+- Updated to PVR API v3.0.0 (API 1.9.7 compatibility mode)
+
 1.11.3
 - Updated to PVR API v2.1.0
 - Automatically fill in platform and library name


### PR DESCRIPTION
Addon part of xbmc/xbmc#7626
Add on currently using 1.9.7 API compatibility code
No further changes required for minimal support
