### PR TITLE
Update to PVR addon API v4.0.0

### DIFF
--- a/pvr.njoy/addon.xml.in
+++ b/pvr.njoy/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.njoy"
-  version="1.11.4"
+  version="1.11.5"
   name="Njoy N7 PVR Client"
   provider-name="Team XBMC">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="3.0.0"/>
+    <import addon="xbmc.pvr" version="4.0.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.njoy/changelog.txt
+++ b/pvr.njoy/changelog.txt
@@ -1,3 +1,6 @@
+1.11.5
+- Updated to PVR API v4.0.0
+
 1.11.4
 - Updated to PVR API v3.0.0 (API 1.9.7 compatibility mode)
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -287,7 +287,7 @@ PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size) { return PVR_ERROR_NO
 int GetTimersAmount(void) { return -1; }
 PVR_ERROR GetTimers(ADDON_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteScheduled) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) {}
 DemuxPacket* DemuxRead(void) { return NULL; }


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.0.0, including a PVR addon micro version bump.

Details can be found here: https://github.com/xbmc/xbmc/pull/8005
