### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.njoy/addon.xml.in
+++ b/pvr.njoy/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.njoy"
-  version="1.11.5"
+  version="1.11.6"
   name="Njoy N7 PVR Client"
-  provider-name="Team XBMC">
+  provider-name="Team Kodi">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.njoy/changelog.txt
+++ b/pvr.njoy/changelog.txt
@@ -1,3 +1,6 @@
+1.11.6
+- Updated to PVR API v4.1.0
+
 1.11.5
 - Updated to PVR API v4.0.0
 


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075
