### PR TITLE
Update to libp8-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,10 @@ option(PACKAGE_ZIP "Package Zip file?" OFF)
 find_package(TinyXML REQUIRED)
 find_package(kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
-find_package(platform REQUIRED)
+find_package(p8-platform REQUIRED)
 
 include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${platform_INCLUDE_DIRS}
+                    ${p8-platform_INCLUDE_DIRS}
                     ${TINYXML_INCLUDE_DIR}
                     ${KODI_INCLUDE_DIR})
 
@@ -22,7 +22,7 @@ set(NJOY_SOURCES src/client.cpp
                  src/N7Xml.cpp)
 
 set(DEPLIBS ${kodiplatform_LIBRARIES}
-            ${platform_LIBRARIES}
+            ${p8-platform_LIBRARIES}
             ${TINYXML_LIBRARIES})
 
 build_addon(pvr.njoy NJOY DEPLIBS)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -23,7 +23,7 @@
 #include "kodi/xbmc_pvr_dll.h"
 #include "kodi/libKODI_guilib.h"
 #include "N7Xml.h"
-#include "platform/util/util.h"
+#include "p8-platform/util/util.h"
 
 using namespace std;
 using namespace ADDON;

--- a/src/client.h
+++ b/src/client.h
@@ -20,7 +20,7 @@
  *
  */
 
-#include "platform/util/StdString.h"
+#include "p8-platform/util/StdString.h"
 #include "kodi/libXBMC_addon.h"
 #include "kodi/libXBMC_pvr.h"
 


### PR DESCRIPTION
Do not merge this! Needs libp8-platform-dev packaging first and it's missing add-on bump.
Also, currently untested.
