### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ enable_language(CXX)
 option(PACKAGE_ZIP "Package Zip file?" OFF)
 
 find_package(TinyXML REQUIRED)
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 

--- a/pvr.njoy/addon.xml.in
+++ b/pvr.njoy/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.njoy"
-  version="2.3.1"
+  version="2.4.0"
   name="Njoy N7 PVR Client"
   provider-name="Team Kodi">
   <requires>

--- a/pvr.njoy/changelog.txt
+++ b/pvr.njoy/changelog.txt
@@ -1,3 +1,6 @@
+2.4.0
+- Cmake: rename find_package kodi to Kodi
+
 2.3.1
 - Fix includes
 


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in
