### PR TITLE
[Nexus] Update for PVR API 8.0.0

### DIFF
--- a/pvr.njoy/changelog.txt
+++ b/pvr.njoy/changelog.txt
@@ -1,3 +1,6 @@
+v20.1.0
+- Kodi API to 8.0.0
+
 v20.0.0
 - Translations updates from Weblate
   - To allow also addon.xml content update by Weblate


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Add supports recordings delete capability
  - Add support for PVR Providers and parental rating code for EPG
  - Enforce EDL limits

**Changes not relate to this addon.**

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395